### PR TITLE
Remove unneeded redirect checks

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func NewBl3Client() (*Bl3Client, error) {
 		return nil, errors.New("Failed to start client")
 	}
 
-	res, err := client.Get("https://raw.githubusercontent.com/jauderho/bl3_auto_vip/master/config.json")
+	res, err := client.Get("https://raw.githubusercontent.com/jauderho/bl3_auto_vip/removevip/config.json")
 	if err != nil {
 		return nil, errors.New("Failed to get config")
 	}

--- a/client.go
+++ b/client.go
@@ -166,7 +166,7 @@ func (client *Bl3Client) Login(username string, password string) error {
 	}
 
 	if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
-		fmt.Println(loginRes.Header.Get(client.Config.LoginRedirectHeader))
+		return errors.New(loginRes.Header.Get(client.Config.LoginRedirectHeader))
 		return errors.New("Failed to start session")
 	}
 

--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func NewBl3Client() (*Bl3Client, error) {
 		return nil, errors.New("Failed to start client")
 	}
 
-	res, err := client.Get("https://raw.githubusercontent.com/matt1484/bl3_auto_vip/master/config.json")
+	res, err := client.Get("https://raw.githubusercontent.com/jauderho/bl3_auto_vip/master/config.json")
 	if err != nil {
 		return nil, errors.New("Failed to get config")
 	}

--- a/client.go
+++ b/client.go
@@ -165,17 +165,15 @@ func (client *Bl3Client) Login(username string, password string) error {
 		return errors.New("Failed to login")
 	}
 
-	err := loginRes.Header.Get(client.Config.LoginRedirectHeader)
-	if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
-		return errors.New(err)
-		//return errors.New("Failed to start session")
+	/* if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
+		return errors.New("Failed to start session")
 	}
 
 	sessionRes, err := client.Get(loginRes.Header.Get(client.Config.LoginRedirectHeader))
 	if err != nil {
 		return errors.New("Failed to get session")
 	}
-	defer sessionRes.Body.Close()
+	defer sessionRes.Body.Close()*/
 
 	client.SetDefaultHeader(client.Config.SessionHeader, loginRes.Header.Get(client.Config.SessionIdHeader))
 	return nil

--- a/client.go
+++ b/client.go
@@ -166,6 +166,7 @@ func (client *Bl3Client) Login(username string, password string) error {
 	}
 
 	if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
+		fmt.Println(loginRes.Header.Get(client.Config.LoginRedirectHeader))
 		return errors.New("Failed to start session")
 	}
 

--- a/client.go
+++ b/client.go
@@ -165,9 +165,10 @@ func (client *Bl3Client) Login(username string, password string) error {
 		return errors.New("Failed to login")
 	}
 
+	err := loginRes.Header.Get(client.Config.LoginRedirectHeader)
 	if loginRes.Header.Get(client.Config.LoginRedirectHeader) == "" {
-		return errors.New(loginRes.Header.Get(client.Config.LoginRedirectHeader))
-		return errors.New("Failed to start session")
+		return errors.New(err)
+		//return errors.New("Failed to start session")
 	}
 
 	sessionRes, err := client.Get(loginRes.Header.Get(client.Config.LoginRedirectHeader))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"time"
 
-	bl3 "github.com/matt1484/bl3_auto_vip"
+	bl3 "github.com/jauderho/bl3_auto_vip"
 	"github.com/shibukawa/configdir"
 )
 
 // gross but effective for now
-const version = "2.1"
+const version = "2.2"
 
 var usernameHash string
 
@@ -284,9 +284,9 @@ func main() {
 
 	doShift(client, singleShiftCode)
 
-	if singleShiftCode == "" {
-		doVip(client)
-	}
+	//if singleShiftCode == "" {
+	//	doVip(client)
+	//}
 
 	exit()
 }

--- a/config.json
+++ b/config.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.1",
+    "version": "2.2",
     "loginUrl": "https://api.2k.com/borderlands/users/authenticate",
     "loginRedirectHeader": "X-CT-REDIRECT",
     "sessionIdHeader": "X-SESSION-SET",
     "sessionHeader": "X-SESSION",
     "requestHeaders": {
         "Origin": "https://borderlands.com",
-        "Referer": "https://borderlands.com/en-US/vip/"
+        "Referer": "https://borderlands.com/en-US/"
     },
     "vipConfig": {
         "codeListUrl": "https://www.reddit.com/r/borderlands3/comments/bxgq5p/borderlands_vip_program_codes/",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/matt1484/bl3_auto_vip
+module github.com/jauderho/bl3_auto_vip
 
 go 1.16
 


### PR DESCRIPTION
Trying to login was resulting in "Failed to start session" messages.

After looking at [](https://github.com/StevenLiekens/shift-up/issues/6) and testing with curl, looks like commenting out L168 to L176 works.

For reference, here's the curl invocation 

`curl -I -d '{"username":"USER", "password":"PASS"}' -H "Content-Type: application/json" -H "Origin: https://borderlands.com" -X POST https://api.2k.com/borderlands/users/authenticate`
